### PR TITLE
Remove unused dependencies and add folders to .vscodeignore

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -9,3 +9,8 @@ vsc-extension-quickstart.md
 **/.eslintrc.json
 **/*.map
 **/*.ts
+helpers/**
+schema/**
+test/**
+react-app/**
+CHANGELOG.md

--- a/package.json
+++ b/package.json
@@ -65,26 +65,21 @@
     "@types/vscode": "^1.51.0",
     "@typescript-eslint/eslint-plugin": "^4.1.1",
     "@typescript-eslint/parser": "^4.1.1",
+    "babel-plugin-rewire": "^1.2.0",
     "chai": "^4.3.4",
+    "del-cli": "^3.0.1",
     "eslint": "^7.9.0",
     "glob": "^7.1.6",
+    "json-schema-to-typescript": "^10.1.1",
     "mocha": "^8.1.3",
+    "recursive-copy-cli": "^1.0.16",
     "ts-mockito": "^2.6.1",
     "typescript": "^4.0.2",
+    "vsce": "^1.83.0",
     "vscode-test": "^1.4.0"
   },
   "dependencies": {
-    "ajv": "^7.0.3",
-    "babel-plugin-rewire": "^1.2.0",
-    "copyfiles": "^2.4.1",
-    "del-cli": "^3.0.1",
     "fs-extra": "^10.0.0",
-    "json-schema-to-typescript": "^10.1.1",
-    "material-ui-icons": "^1.0.0-beta.36",
-    "node-cmd": "^4.0.0",
-    "recursive-copy-cli": "^1.0.16",
-    "rimraf": "^3.0.2",
-    "ts-node": "^9.1.1",
-    "vsce": "^1.83.0"
+    "ts-node": "^9.1.1"
   }
 }


### PR DESCRIPTION
- Remove unused deps or move to devdeps
- Add subfolders to .vscodeignore, so they are not bundled into the extension
Closes #33

Signed-off-by: Max Elia Schweigkofler <max_elia@hotmail.de>