### PR TITLE
Show terminalCommands output during execution

### DIFF
--- a/src/Functions/openFile.ts
+++ b/src/Functions/openFile.ts
@@ -13,10 +13,10 @@ import {OpenFile} from '../../schema/tutorial';
 import ReactPanel from '../ReactPanel';
 const path = require('path');
 
-export const openFile = async (openFIleCommand: OpenFile, id: String) => {
+export const openFile = async (openFileCommand: OpenFile, id: String) => {
 
   const workspaceFolder: string = vscode.workspace.rootPath || '~';
-  const filepath = path.join(workspaceFolder, openFIleCommand.openFile);
+  const filepath = path.join(workspaceFolder, openFileCommand.openFile);
 
   try {
     const uri = vscode.Uri.file(filepath);

--- a/src/ReactPanel.ts
+++ b/src/ReactPanel.ts
@@ -116,6 +116,7 @@ class ReactPanel {
           startAssistance(assistance, ids[commands.indexOf(command)]);
           break;
       }
+      await new Promise(r => setTimeout(r, 500));
     }
   }
 


### PR DESCRIPTION
- Change `exec` to `spawn` in order to show output during execution, fixes eclipsesource/glsp-tutorial#19
- Set short timeout between different extension-commands to make sure that 'openFile' can find files created previously with 'terminalCommands', fixes eclipsesource/glsp-tutorial#20

Signed-off-by: Max Elia Schweigkofler <max_elia@hotmail.de>